### PR TITLE
Fix variable definitions and declarations in bh

### DIFF
--- a/bh/src/args.c
+++ b/bh/src/args.c
@@ -1,7 +1,7 @@
 /* For copyright information, see olden_v1.0/COPYRIGHT */
 #include <stdlib.h>
 
-extern int NumNodes;
+int NumNodes;
 extern int nbody;
 
 int dealwithargs(int argc, char *argv[]) {

--- a/bh/src/defs.h
+++ b/bh/src/defs.h
@@ -17,7 +17,7 @@
 #define RETEST();
 /*#define isnan(xxx) 0*/
 #define PID(xxx) 0
-int NumNodes;
+extern int NumNodes;
 #endif
 
 
@@ -192,15 +192,15 @@ typedef struct {
  * ROOT: origin of tree; declared as nodeptr for tree with only 1 body.
  */
 
-global nodeptr root;
+extern nodeptr root;
 
 /*
  * Integerized coordinates: used to mantain body-tree.
  */
 
-global vector rmin;		/* lower-left corner of coordinate box      */
+extern vector rmin;		/* lower-left corner of coordinate box      */
 
-global real xxxrsize;		/* side-length of integer coordinate box    */
+extern real xxxrsize;		/* side-length of integer coordinate box    */
 
 #define IMAX_SHIFT (8 * sizeof(int) - 2)
 #define IMAX  (1 << (8 * sizeof(int) - 2))    /* highest bit of int coord */

--- a/bh/src/newbh.c
+++ b/bh/src/newbh.c
@@ -15,6 +15,11 @@
 
 int nbody;
 
+extern nodeptr root;
+extern vector rmin;
+extern real xxxrsize;
+
+
 double sqrt(), xrand(), my_rand();
 real pow();
 extern icstruct intcoord(bodyptr p, treeptr t);


### PR DESCRIPTION
Some variables were defined in the header file, whereas declared as `extern` in the source file, which made clang fail to link. This commit swaps these definitions/declarations.